### PR TITLE
XMacro registry for new commands

### DIFF
--- a/async_design/main.cpp
+++ b/async_design/main.cpp
@@ -10,14 +10,12 @@
 #include "cmd_modules/command.h"
 #include "cmd_modules/virtual_constructor.h"
 
-using namespace std;
-
 static const int kPoolThreadCount = 4;
 
 //=============================================================================
 struct ThreadInfo {
   int thread_id;
-  istream* file;
+  std::istream* file;
 };
 
 //=============================================================================
@@ -44,15 +42,18 @@ int main(int argc, char* argv[]) {
   int res;
   void* status = NULL;
 
+  // Initialize the virtual constructor class.
+  cmd_modules::VirtualConstructor::Instance()->Init();
+
   if (argc != 2) {
-    cout << "Usage: cmdEx <command File>" << endl;
+    std::cout << "Usage: Command <command File>" << std::endl;
     return 1;
   }
 
-  ifstream command_file(argv[1]);
+  std::ifstream command_file(argv[1]);
 
   if (!command_file.is_open()) {
-    cout << "Error: Can't open file." << endl;
+    std::cout << "Error: Can't open file." << std::endl;
     return 1;
   }
 
@@ -63,7 +64,8 @@ int main(int argc, char* argv[]) {
     info[i].file = &command_file;
     res = pthread_create(&thread[i], &attr, ThreadRoutine, (void*)&info[i]);
     if (res) {
-      cout << "Error: Can't create thread: " << i << endl;
+      std::cout << "Error: Can't create thread: " << std::to_string(i)
+                << std::endl;
     }
   }
 
@@ -72,11 +74,11 @@ int main(int argc, char* argv[]) {
   for (int i = 0; i < kPoolThreadCount; i++) {
     pthread_join(thread[i], &status);
     if (status) {
-      cout << "Error: Joining thread: " << i << endl;
+      std::cout << "Error: Joining thread: " << std::to_string(i) << std::endl;
     }
   }
 
-  //~ commandFile.close();
+  command_file.close();
 
   pthread_exit(NULL);
 }

--- a/cmd_modules/CMakeLists.txt
+++ b/cmd_modules/CMakeLists.txt
@@ -7,6 +7,7 @@ project(${LIBRARY_NAME})
 set(HEADER_FILES
     inc/cmd_modules/checksum.h
     inc/cmd_modules/command.h
+    inc/cmd_modules/command_modules.h
     inc/cmd_modules/file_command.h
     inc/cmd_modules/virtual_constructor.h
     inc/cmd_modules/word_count.h

--- a/cmd_modules/inc/cmd_modules/checksum.h
+++ b/cmd_modules/inc/cmd_modules/checksum.h
@@ -3,23 +3,20 @@
 
 #include <string>
 
+#include "cmd_modules/file_command.h"
+#include "cmd_modules/virtual_constructor.h"
 #include "tools/csv_parser.h"
 
-#include "cmd_modules/virtual_constructor.h"
-#include "cmd_modules/file_command.h"
-
 namespace cmd_modules {
-class Checksum: public FileCommand{
-public:
-	Checksum(){ checksum_ = 0;}
-	Checksum(VirtualConstructor* VC)
-		{VC->RegisterCommand(this);}
-	Checksum* Clone(){ return new Checksum;}
-	void Deserialize(tools::CSVParser &params);
-	int Execute();
-	std::string GetId(){ return "CHECKSUM";}
-private:
-	unsigned char checksum_;
+class Checksum : public FileCommand {
+ public:
+  Checksum(std::string command_id);
+  Checksum* Clone() { return new Checksum(command_id_); }
+  void Deserialize(tools::CSVParser& params);
+  int Execute();
+
+ private:
+  unsigned char checksum_;
 };
 
-}
+}  // namespace cmd_modules

--- a/cmd_modules/inc/cmd_modules/command.h
+++ b/cmd_modules/inc/cmd_modules/command.h
@@ -7,13 +7,16 @@
 #include "tools/csv_parser.h"
 
 namespace cmd_modules {
-class Command{
-public:
-	Command(){}
-	virtual ~Command(){}
-	virtual Command* Clone() = 0;
-	virtual void Deserialize(tools::CSVParser &params) = 0;
-	virtual int Execute() = 0;
-	virtual std::string GetId() = 0;
+class Command {
+ public:
+  Command() {}
+  virtual ~Command() {}
+  virtual Command* Clone() = 0;
+  virtual void Deserialize(tools::CSVParser& params) = 0;
+  virtual int Execute() = 0;
+  std::string GetId() { return command_id_; }
+
+ protected:
+  std::string command_id_;
 };
-}
+}  // namespace cmd_modules

--- a/cmd_modules/inc/cmd_modules/command_modules.h
+++ b/cmd_modules/inc/cmd_modules/command_modules.h
@@ -1,0 +1,11 @@
+// This file is where commands are registered.
+#pragma once
+
+#include "cmd_modules/checksum.h"
+#include "cmd_modules/word_count.h"
+#include "cmd_modules/word_freq.h"
+
+#define LIST_OF_COMMANDS(COMMAND) \
+COMMAND(cmd_modules, Checksum, "CHECKSUM") \
+COMMAND(cmd_modules, WordCount, "WORDCOUNT") \
+COMMAND(cmd_moduels, WordFreq, "WORDFREQ")

--- a/cmd_modules/inc/cmd_modules/file_command.h
+++ b/cmd_modules/inc/cmd_modules/file_command.h
@@ -2,24 +2,23 @@
 // paramters needed for reading from a file.
 #pragma once
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
+#include "cmd_modules/command.h"
 #include "tools/csv_parser.h"
 
-#include "cmd_modules/command.h"
-
 namespace cmd_modules {
-class FileCommand: public Command {
-public:
-	FileCommand(){}
-	virtual ~FileCommand(){}
-	virtual Command* Clone() = 0;
-	virtual void Deserialize(tools::CSVParser &params) = 0;
-	virtual int Execute() = 0;
-	virtual std::string GetId() = 0;
-protected:
-	std::string filename_;
+class FileCommand : public Command {
+ public:
+  FileCommand() {}
+  virtual ~FileCommand() {}
+  virtual Command* Clone() = 0;
+  virtual void Deserialize(tools::CSVParser& params) = 0;
+  virtual int Execute() = 0;
+
+ protected:
+  std::string filename_;
 };
-}
+}  // namespace cmd_modules

--- a/cmd_modules/inc/cmd_modules/virtual_constructor.h
+++ b/cmd_modules/inc/cmd_modules/virtual_constructor.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <pthread.h>
+
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -12,19 +14,20 @@ namespace cmd_modules {
 using namespace std;
 
 class VirtualConstructor {
-	static VirtualConstructor* object_;
+ public:
+  ~VirtualConstructor();
+  void Init();
+  static VirtualConstructor* Instance();
+  Command* CreateCommand(istream*);
 
-	typedef unordered_map<string, Command*> CommandRegistry;
+ private:
+  static VirtualConstructor* object_;
 
-	CommandRegistry registry_;
-	pthread_mutex_t mtx_;
+  typedef unordered_map<string, std::unique_ptr<Command>> CommandRegistry;
 
-	VirtualConstructor();
-public:
-	~VirtualConstructor();
-	static VirtualConstructor* Instance();
-	void RegisterCommand(Command *cmd);
-	Command* CreateCommand(istream*);
+  CommandRegistry registry_;
+  pthread_mutex_t mtx_;
+
+  VirtualConstructor();
 };
-}
-
+}  // namespace cmd_modules

--- a/cmd_modules/inc/cmd_modules/word_count.h
+++ b/cmd_modules/inc/cmd_modules/word_count.h
@@ -3,22 +3,19 @@
 
 #include <string>
 
-#include "tools/csv_parser.h"
-
 #include "cmd_modules/file_command.h"
 #include "cmd_modules/virtual_constructor.h"
+#include "tools/csv_parser.h"
 
 namespace cmd_modules {
-class WordCount: public FileCommand{
-public:
-	WordCount() { word_count_ = 0;}
-	WordCount(VirtualConstructor* VC)
-		{VC->RegisterCommand(this);}
-	Command* Clone(){ return new WordCount;}
-	void Deserialize(tools::CSVParser &params);
-	int Execute();
-	std::string GetId(){ return "WORDCOUNT";}
-private:
-	unsigned int word_count_;
+class WordCount : public FileCommand {
+ public:
+  WordCount(std::string command_id);
+  Command* Clone() { return new WordCount(command_id_); }
+  void Deserialize(tools::CSVParser& params);
+  int Execute();
+
+ private:
+  unsigned int word_count_;
 };
-}
+}  // namespace cmd_modules

--- a/cmd_modules/inc/cmd_modules/word_freq.h
+++ b/cmd_modules/inc/cmd_modules/word_freq.h
@@ -3,23 +3,20 @@
 
 #include <string>
 
-#include "tools/csv_parser.h"
-
 #include "cmd_modules/file_command.h"
 #include "cmd_modules/virtual_constructor.h"
+#include "tools/csv_parser.h"
 
 namespace cmd_modules {
-class WordFreq: public FileCommand{
-public:
-	WordFreq(){ freq_count_ = 0;}
-	WordFreq(VirtualConstructor* VC)
-		{VC->RegisterCommand(this);}
-	Command* Clone(){ return new WordFreq;}
-	void Deserialize(tools::CSVParser &params);
-	int Execute();
-	std::string GetId(){ return "WORDFREQ";}
-private:
-	std::string word_;
-	unsigned int freq_count_;
+class WordFreq : public FileCommand {
+ public:
+  WordFreq(std::string command_id);
+  Command* Clone() { return new WordFreq(command_id_); }
+  void Deserialize(tools::CSVParser& params);
+  int Execute();
+
+ private:
+  std::string word_;
+  unsigned int freq_count_;
 };
-}
+}  // namespace cmd_modules

--- a/cmd_modules/src/checksum.cpp
+++ b/cmd_modules/src/checksum.cpp
@@ -33,6 +33,11 @@ static const unsigned char crc8[256] = {
     0xFA, 0xFD, 0xF4, 0xF3};
 
 //=============================================================================
+Checksum::Checksum(std::string command_id) : checksum_(0) {
+  command_id_ = command_id;
+}
+
+//=============================================================================
 void Checksum::Deserialize(tools::CSVParser &params) {
   filename_ = params.Next();
 }
@@ -67,7 +72,4 @@ int Checksum::Execute() {
 
   return 0;
 }
-
-//=============================================================================
-Checksum ChecksumType(VirtualConstructor::Instance());
 }  // namespace cmd_modules

--- a/cmd_modules/src/word_count.cpp
+++ b/cmd_modules/src/word_count.cpp
@@ -8,6 +8,11 @@
 
 namespace cmd_modules {
 //=============================================================================
+WordCount::WordCount(std::string command_id) : word_count_(0) {
+  command_id_ = command_id;
+}
+
+//=============================================================================
 void WordCount::Deserialize(tools::CSVParser &params) {
   filename_ = params.Next();
 }
@@ -40,7 +45,4 @@ int WordCount::Execute() {
 
   return 0;
 }
-
-//=============================================================================
-WordCount WordCountType(VirtualConstructor::Instance());
 }  // namespace cmd_modules

--- a/cmd_modules/src/word_freq.cpp
+++ b/cmd_modules/src/word_freq.cpp
@@ -6,6 +6,11 @@
 
 namespace cmd_modules {
 //=============================================================================
+WordFreq::WordFreq(std::string command_id) : freq_count_(0) {
+  command_id_ = command_id;
+}
+
+//=============================================================================
 void WordFreq::Deserialize(tools::CSVParser &params) {
   filename_ = params.Next();
   word_ = params.Next();
@@ -45,7 +50,4 @@ int WordFreq::Execute() {
 
   return 0;
 }
-
-//=============================================================================
-WordFreq WordFreqType(VirtualConstructor::Instance());
 }  // namespace cmd_modules

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 # Update and upgrade
-sudo apt update
-sudo apt upgrade
-sudo apt install clang-format cmake cmake-curses-gui g++ gcc git make ninja-build perl ripgrep vim
+sudo apt update -qq
+sudo apt upgrade -qq -y
+sudo apt install -qq -y ccache clang-format cmake cmake-curses-gui g++ gcc git make ninja-build perl ripgrep vim
 
 # Create directories
 FILE=~/code
@@ -13,10 +13,10 @@ fi
 FILE=~/qtcreator-4.4.1
 if [ ! -d "$FILE" ]; then
 	printf "\n\n"
-	printf "Download QT creator: https://download.qt.io/archive/qtcreator/"
-	printf "BugMeNot: http://bugmenot.com/view/qt.io"
-	printf "Set theme and Enalbe beautifier, restart qt"
-	printf "Tools -> Options -> Beautifier -> Clang Format -> Google/auto"
+	printf "Download QT creator: https://download.qt.io/archive/qtcreator/\n"
+	printf "BugMeNot: http://bugmenot.com/view/qt.io\n"
+	printf "Set theme and Enalbe beautifier, restart qt\n"
+	printf "Tools -> Options -> Beautifier -> Clang Format -> Google/autosave\n"
 	printf "\n\n"
 fi
 
@@ -34,5 +34,6 @@ git clone git@github.com:nathanielpohl/AsyncDesign.git ./AsyncDesign
 git config --global user.email "nathaniel.pohl@gmail.com"
 git config --global user.name "Nathaniel Pohl"
 cd ./AsyncDesign
-mkdir build && cd build
+mkdir -p build && cd build
 cmake -G "Ninja"  ..
+ninja


### PR DESCRIPTION
Added Xmacros for registering commands.

Moving to the new ninja/cmake build system, there was a bug where none of the commands where being registered. This new way of registering commands allows for:
1. Less bloat in the individual commands, so there is no more calling for the VirtualCommand::Instance to register. 
2. Will allow the Virtual Command class to be pulled into its own modules if I want to in the future, allowing for different sub modules (not just the ones under the cmd_modules module) to register as a command. 